### PR TITLE
refactor: CategoryRepository 수정

### DIFF
--- a/BE/src/main/java/com/team25/sidedish/repository/CategoryRepository.java
+++ b/BE/src/main/java/com/team25/sidedish/repository/CategoryRepository.java
@@ -1,7 +1,11 @@
 package com.team25.sidedish.repository;
 
 import com.team25.sidedish.domain.Category;
+import java.util.List;
 import org.springframework.data.repository.CrudRepository;
 
 public interface CategoryRepository extends CrudRepository<Category, Long> {
+
+    @Override
+    List<Category> findAll();
 }

--- a/BE/src/test/java/com/team25/sidedish/repository/CategoryRepositoryTest.java
+++ b/BE/src/test/java/com/team25/sidedish/repository/CategoryRepositoryTest.java
@@ -27,7 +27,7 @@ class CategoryRepositoryTest {
     @DisplayName("카테고리 목록을 조회할 수 있다")
     void 카테고리_목록_조회_테스트() {
         // when
-        List<Category> results = Lists.newArrayList(categoryRepository.findAll());
+        List<Category> results = categoryRepository.findAll();
 
         // then
         assertThat(results).hasSize(CATEGORY_COUNT);


### PR DESCRIPTION
### 💡 Issue Number

close #79

### 📙 작업 내역

- [x]  CategoryRepository 인터페이스의 `findAll` 메소드 반환타입을 `Iterable` -> `List` 로 수정하였습니다.
- [x] 위 변경사항에 따라 테스트코드도 수정하였습니다.

### 📘 작업 유형

- 리펙토링

<br/><br/>